### PR TITLE
Add retries to clear redfish job queue tasks

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -106,11 +106,19 @@
   shell: |
     {{ badfish_cmd }}{{ item }} --clear-jobs
   with_items: "{{ master_fqdns }}"
+  register: master_redfish
+  until: master_redfish is succeeded
+  retries: 3
+  delay: 30
 
 - name: Clear worker nodes redfish job queue
   shell: |
     {{ badfish_cmd }}{{ item }} --clear-jobs
   with_items: "{{ worker_fqdns }}"
+  register: worker_redfish
+  until: worker_redfish is succeeded
+  retries: 3
+  delay: 30
 
 - name: Set master nodes to director boot order
   shell: |


### PR DESCRIPTION
Sometimes the playbook fails as the job queue cannot be cleared
on the first attempt.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
