### PR TITLE
ocp4-lab.dnsmasq.conf.j2

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.dnsmasq.conf.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.dnsmasq.conf.j2
@@ -10,7 +10,6 @@ interface=baremetal
 dhcp-range={{ extcidrnet | next_nth_usable(10) }},{{ extcidrnet | ipaddr('last_usable') }}
 dhcp-no-override
 dhcp-authoritative
-dhcp-lease-max=41
 {% for mac in master_bm_macs %}
 dhcp-host={{ mac }},{{ extcidrnet | next_nth_usable(loop.index0 + 10) }},master-{{ loop.index0 }}
 {% endfor %}


### PR DESCRIPTION
removing the limitation to 41 dhcp leases