### PR TITLE
Create fake root on localhost

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -197,21 +197,24 @@
     enabled: yes
   become: yes
 
-- name: Set fake root directory path
-  set_fact:
-    fake_root: "{{ playbook_dir }}/roles/installer/files/customize_filesystem/master/etc/sysconfig/network-scripts"
+- name: Create fake root
+  block:
+    - name: Set fake root directory path
+      set_fact:
+        fake_root: "{{ playbook_dir }}/roles/installer/files/customize_filesystem/master/etc/sysconfig/network-scripts"
 
-- name: Create fake root directory
-  file:
-    path: "{{ fake_root }}"
-    state: directory
-    mode: 0777
-  become: yes
+    - name: Create fake root directory
+      file:
+        path: "{{ fake_root }}"
+        state: directory
+        mode: 0777
+      become: yes
 
-- name: Create ifcfg files to disable NICs
-  template:
-    src: ocp4-lab.ifcfg-template.j2
-    dest: "{{ fake_root }}/ifcfg-{{ item }}"
-    mode: 0644
-  become: yes
-  with_items: "{{ disable_nics }}"
+    - name: Create ifcfg files to disable NICs
+      template:
+        src: ocp4-lab.ifcfg-template.j2
+        dest: "{{ fake_root }}/ifcfg-{{ item }}"
+        mode: 0644
+      become: yes
+      with_items: "{{ disable_nics }}"
+  delegate_to: localhost


### PR DESCRIPTION
# Description
This needed to allow the playbook to be run from outside the provisioning host and support https://github.com/openshift-kni/baremetal-deploy/commit/b9f5d63814b7f62c7b452a9bca7ba2941e614d41